### PR TITLE
Additional configuration options via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ API_KEY=mykey syncthing-hooks
 
 Don't forget to substitute `mykey` with your syncthing API key, which can be found in the settings in the GUI.
 
+If Syncthing runs on another host or listens to a non-default port, you can specify an URL by using `ST_URL`.
+Note that this URL has to include the protocol, hostname, port and path, e.g.:
+
+```
+ST_URL=http://<ip>:8384/rest/events
+```
+
 It won't install itself as a daemon by default, however. In order to run it as a service, it is recommended to install [pm2](https://pm2.keymetrics.io/):
 
 ```sh
@@ -44,7 +51,9 @@ pm2 logs
 
 ## Hooks
 
-Create a folder in your home directory called `.syncthing-hooks`. Each hook is a file with the following naming scheme:
+Create a folder in your home directory called `.syncthing-hooks`.
+A different directory can be set using `ST_HOOK_ROOT`.
+Each hook is a file with the following naming scheme:
 
 `folder-name-delay`
 

--- a/api.js
+++ b/api.js
@@ -1,9 +1,10 @@
 const got = require('got');
+const { getEnvVar } = require('./env.js');
 
 const fetchEvents = () =>
   got('http://localhost:8384/rest/events', {
     headers: {
-      'X-API-Key': process.env.API_KEY,
+      'X-API-Key': getEnvVar('API_KEY','invalid')
     },
   }).json();
 

--- a/api.js
+++ b/api.js
@@ -2,7 +2,7 @@ const got = require('got');
 const { getEnvVar } = require('./env.js');
 
 const fetchEvents = () =>
-  got('http://localhost:8384/rest/events', {
+  got(getEnvVar('ST_URL','http://localhost:8384/rest/events'), {
     headers: {
       'X-API-Key': getEnvVar('API_KEY','invalid')
     },

--- a/env.js
+++ b/env.js
@@ -1,0 +1,9 @@
+module.exports = {
+    getEnvVar: function (varname, defaultvalue){
+        var result = process.env[varname];
+        if(result!=undefined)
+            return result;
+        else
+            return defaultvalue;
+    }
+};

--- a/hooks.js
+++ b/hooks.js
@@ -5,7 +5,7 @@ const path = require('path');
 const { spawn } = require('child_process');
 const { getEnvVar } = require('./env.js');
 
-const getHooksRoot = () => getEnvVar('ST_HOOK_DIR', path.join(os.homedir(), '/.syncthing-hooks'))
+const getHooksRoot = () => getEnvVar('ST_HOOK_ROOT', path.join(os.homedir(), '/.syncthing-hooks'))
 
 const readHooksRoot = async root => {
   try {

--- a/hooks.js
+++ b/hooks.js
@@ -3,8 +3,9 @@ const ms = require('ms');
 const os = require('os');
 const path = require('path');
 const { spawn } = require('child_process');
+const { getEnvVar } = require('./env.js');
 
-const getHooksRoot = () => path.join(os.homedir(), '/.syncthing-hooks');
+const getHooksRoot = () => getEnvVar('ST_HOOK_DIR', path.join(os.homedir(), '/.syncthing-hooks'))
 
 const readHooksRoot = async root => {
   try {


### PR DESCRIPTION
The proposed changes add the ability to:
- specify a non-standard URL via the environment variable `ST_URL`, which is useful if Syncthing runs on another host or behind a non-default port.
- specify a hook-root other than `~/.syncthing-hooks` via the environment variable `ST_HOOK_ROOT`.

This is achieved by implementing the function `getEnvVar`, which defaults the original value if the variable is not present. This ensures backward-compatibility.

To maintain consistency, `getEnvVar` now is used to set the `API_KEY` and defaults to 'invalid' if no key was provided.

Usage:
`API_KEY=<yourkey> ST_URL=<URL> ST_HOOK_ROOT=</path/to/hooks> syncthing-hooks`
