### PR TITLE
Remove 11-character requirement on folder names. Fixes #1.

### DIFF
--- a/hooks.js
+++ b/hooks.js
@@ -21,7 +21,7 @@ const parseHooks = (root, hooks) =>
   hooks
     .map(x => ({
       path: path.join(root, x),
-      match: x.match(/(?<folder>.{11})-(?<time>.*)/),
+      match: x.match(/(?<folder>.*)-(?<time>.*)/),
     }))
     .filter(x => x.match)
     .map(x => ({


### PR DESCRIPTION
Hello,

Thanks for the handy package!

Is this all that's required to address #1?

Thanks,
Oliver